### PR TITLE
feat: add focal-spiral playback ordering

### DIFF
--- a/components/app.tsx
+++ b/components/app.tsx
@@ -6,6 +6,7 @@ import { useDropzone } from "react-dropzone";
 import type { ColorChoice } from "../src/extraction";
 import { convert } from "../src/image";
 import type { NoteConversion } from "../src/notes";
+import type { OrderMethod } from "../src/order";
 import type { RefineMethod } from "../src/refine";
 import type { RegionMethod } from "../src/regions";
 import { meanKeyTempo, type TempoMethod } from "../src/tempo";
@@ -20,6 +21,7 @@ export default function App(): React.ReactElement {
   const [bpm, setBpm] = useState<number | null>(80);
   const [duration, setDuration] = useState<number | null>(30); // how long should this range be?
   const [region, setRegion] = useState<RegionMethod>("grid");
+  const [orderMethod, setOrderMethod] = useState<OrderMethod>("word");
   const [colorChoice, setColorChoice] = useState<ColorChoice>("proportional");
   const [minStd, setMinStd] = useState<number | null>(0.04);
   const [noteMethod, setNoteMethod] = useState<NoteConversion>("hslc");
@@ -109,6 +111,7 @@ export default function App(): React.ReactElement {
             bpm,
             duration,
             region,
+            order: orderMethod,
             colorChoice,
             minStd,
             noteMethod,
@@ -142,6 +145,7 @@ export default function App(): React.ReactElement {
     bpm,
     duration,
     region,
+    orderMethod,
     colorChoice,
     refineMethod,
     minWeight,
@@ -195,6 +199,8 @@ export default function App(): React.ReactElement {
           setDuration={setDuration}
           region={region}
           setRegion={setRegion}
+          orderMethod={orderMethod}
+          setOrderMethod={setOrderMethod}
           colorChoice={colorChoice}
           setColorChoice={setColorChoice}
           minStd={minStd}

--- a/components/controls.tsx
+++ b/components/controls.tsx
@@ -1,6 +1,7 @@
 "use client";
 import type { ColorChoice } from "../src/extraction";
 import type { NoteConversion } from "../src/notes";
+import type { OrderMethod } from "../src/order";
 import type { RefineMethod } from "../src/refine";
 import type { RegionMethod } from "../src/regions";
 import type { TempoMethod } from "../src/tempo";
@@ -20,6 +21,8 @@ export default function Controls({
   setDuration,
   region,
   setRegion,
+  orderMethod,
+  setOrderMethod,
   colorChoice,
   setColorChoice,
   minStd,
@@ -48,6 +51,8 @@ export default function Controls({
   setDuration: (dur: number | null) => void;
   region: RegionMethod;
   setRegion: (region: RegionMethod) => void;
+  orderMethod: OrderMethod;
+  setOrderMethod: (method: OrderMethod) => void;
   colorChoice: ColorChoice;
   setColorChoice: (choice: ColorChoice) => void;
   minStd: number | null;
@@ -172,6 +177,15 @@ export default function Controls({
         value={region}
         set={setRegion}
         values={[["grid", "Grid"]]}
+      />
+      <TypedSelector
+        title="Order Selection"
+        value={orderMethod}
+        set={setOrderMethod}
+        values={[
+          ["word", "Word Order"],
+          ["focal-spiral", "Focal Spiral"],
+        ]}
       />
       <TypedSelector
         title="Note Conversion"

--- a/src/order.spec.ts
+++ b/src/order.spec.ts
@@ -1,0 +1,89 @@
+import { expect, test } from "bun:test";
+import { type OrderMethod, order } from "./order";
+import type { Region } from "./regions";
+
+/** a minimal region; only center and variance matter to ordering */
+function region(center: [number, number], variance: number): Region {
+  return { center, variance, colors: [], num: 0, poly: [] };
+}
+
+/** a row-major grid whose only colorful (focal) cell is at [focalRow, focalCol] */
+function grid(
+  rows: number,
+  cols: number,
+  focalRow: number,
+  focalCol: number,
+): Region[] {
+  const items: Region[] = [];
+  for (let row = 0; row < rows; ++row) {
+    for (let col = 0; col < cols; ++col) {
+      items.push(
+        region([col, row], row === focalRow && col === focalCol ? 1 : 0),
+      );
+    }
+  }
+  return items;
+}
+
+function sortedCenters(regions: readonly Region[]): [number, number][] {
+  return regions
+    .map((reg) => reg.center)
+    .sort((left, right) => left[0] - right[0] || left[1] - right[1]);
+}
+
+test("word order recovers reading order from jittered rows", () => {
+  // y values jitter within a row but stay well inside the unit spacing
+  const items = [
+    region([2, 0.1], 0),
+    region([0, 0.0], 0),
+    region([1, 0.2], 0),
+    region([1, 1.1], 0),
+    region([0, 0.9], 0),
+    region([2, 1.0], 0),
+  ];
+  expect(order(items, "word").map((reg) => reg.center)).toEqual([
+    [0, 0],
+    [1, 0.2],
+    [2, 0.1],
+    [0, 0.9],
+    [1, 1.1],
+    [2, 1.0],
+  ]);
+});
+
+test("focal spiral starts at the most colorful region", () => {
+  const items = grid(3, 3, 1, 1);
+  expect(order(items, "focal-spiral")[0].center).toEqual([1, 1]);
+});
+
+test("focal spiral visits in non-decreasing distance from the focal point", () => {
+  const result = order(grid(5, 5, 2, 2), "focal-spiral");
+  const focal = result[0].center;
+  const radii = result.map((reg) =>
+    Math.hypot(reg.center[0] - focal[0], reg.center[1] - focal[1]),
+  );
+  // a tight spiral should never jump far outward and then back inward; allow a
+  // one-spacing tolerance for the rotational component
+  for (let i = 1; i < radii.length; ++i) {
+    expect(radii[i]).toBeGreaterThanOrEqual(radii[i - 1] - 1.0001);
+  }
+});
+
+test("order returns a permutation of all regions", () => {
+  const items = grid(4, 3, 2, 1);
+  for (const method of ["word", "focal-spiral"] as const) {
+    const result = order(items, method);
+    expect(result.length).toBe(items.length);
+    expect(sortedCenters(result)).toEqual(sortedCenters(items));
+  }
+});
+
+test("a single region is returned as-is for every method", () => {
+  const solo = region([3, 4], 0);
+  for (const method of [
+    "word",
+    "focal-spiral",
+  ] as const satisfies OrderMethod[]) {
+    expect(order([solo], method)).toEqual([solo]);
+  }
+});

--- a/src/order.ts
+++ b/src/order.ts
@@ -1,0 +1,137 @@
+/** order regions for playback, independent of how they were carved */
+
+import type { Region } from "./regions";
+
+export type OrderMethod = "word" | "focal-spiral";
+
+/**
+ * median nearest-neighbor distance among centers
+ *
+ * this is the natural length scale of a region layout, used to set the row
+ * tolerance for word order and the spiral tightness for focal spiral. it is
+ * only meaningful with at least two points.
+ */
+function medianSpacing(centers: [number, number][]): number {
+  const count = centers.length;
+  if (count < 2) {
+    throw new Error("median spacing needs at least two centers");
+  }
+  const nearest: number[] = [];
+  for (let i = 0; i < count; ++i) {
+    let best = Number.POSITIVE_INFINITY;
+    for (let j = 0; j < count; ++j) {
+      if (i === j) {
+        continue;
+      }
+      const dx = centers[i][0] - centers[j][0];
+      const dy = centers[i][1] - centers[j][1];
+      const dist = Math.hypot(dx, dy);
+      if (dist < best) {
+        best = dist;
+      }
+    }
+    nearest.push(best);
+  }
+  nearest.sort((left, right) => left - right);
+  const mid = Math.floor(nearest.length / 2);
+  if (nearest.length % 2 === 0) {
+    return (nearest[mid - 1] + nearest[mid]) / 2;
+  } else {
+    return nearest[mid];
+  }
+}
+
+/**
+ * reading order: top-to-bottom, left-to-right
+ *
+ * a plain lexicographic sort on floating-point centers would zig-zag whenever
+ * two regions in the same visual row differ slightly in y, so we group centers
+ * into rows by approximate y (within half the median spacing) and sort each row
+ * by x.
+ */
+function wordOrder(regions: Region[]): Region[] {
+  const centers = regions.map((region) => region.center);
+  const rowTolerance = medianSpacing(centers) / 2;
+  const byHeight = regions.map((_, index) => index);
+  byHeight.sort((left, right) => centers[left][1] - centers[right][1]);
+
+  const ordered: Region[] = [];
+  let row: number[] = [];
+  let rowTop = Number.NEGATIVE_INFINITY;
+  const flush = () => {
+    row.sort((left, right) => centers[left][0] - centers[right][0]);
+    for (const index of row) {
+      ordered.push(regions[index]);
+    }
+    row = [];
+  };
+  for (const index of byHeight) {
+    if (row.length > 0 && centers[index][1] - rowTop >= rowTolerance) {
+      flush();
+    }
+    if (row.length === 0) {
+      rowTop = centers[index][1];
+    }
+    row.push(index);
+  }
+  flush();
+  return ordered;
+}
+
+/**
+ * focal spiral: start at the most colorful region and spiral outward
+ *
+ * we model an Archimedean spiral r = a·θ centered on the most colorful region
+ * (the one with the largest color variance), with the arm spacing a·2π set to
+ * the median region spacing so successive turns sit about one region apart. each
+ * region is placed at the spiral position it most nearly lies on: at polar
+ * offset (radius, angle) the spiral passes through radius at total angles
+ * angle + 2π·k, so we pick the turn k whose radius best matches and sort
+ * ascending by that total angle. the focal region (radius 0) sorts first;
+ * everything else falls onto progressively outer turns.
+ */
+function focalSpiralOrder(regions: Region[]): Region[] {
+  let focal = 0;
+  for (let i = 1; i < regions.length; ++i) {
+    if (regions[i].variance > regions[focal].variance) {
+      focal = i;
+    }
+  }
+  const [focalX, focalY] = regions[focal].center;
+  const centers = regions.map((region) => region.center);
+  // arm spacing a·2π ≈ region spacing, so a = spacing / 2π (clamped off zero)
+  const armScale = Math.max(medianSpacing(centers), 1e-9) / (2 * Math.PI);
+  const turn = 2 * Math.PI;
+
+  const score = regions.map((region) => {
+    const dx = region.center[0] - focalX;
+    const dy = region.center[1] - focalY;
+    const radius = Math.hypot(dx, dy);
+    let angle = Math.atan2(dy, dx);
+    if (angle < 0) {
+      angle += turn;
+    }
+    const turns = Math.max(0, Math.round((radius / armScale - angle) / turn));
+    return angle + turn * turns;
+  });
+
+  const indices = regions.map((_, index) => index);
+  indices.sort((left, right) => score[left] - score[right]);
+  return indices.map((index) => regions[index]);
+}
+
+/** reorder regions into the playback order for the given method */
+export function order(regions: Region[], method: OrderMethod): Region[] {
+  // a single region (or none) has only one ordering, and the spacing-based
+  // heuristics are undefined there
+  if (regions.length < 2) {
+    return [...regions];
+  }
+  if (method === "word") {
+    return wordOrder(regions);
+  } else if (method === "focal-spiral") {
+    return focalSpiralOrder(regions);
+  } else {
+    throw new Error(`unknown order method ${method}`);
+  }
+}

--- a/src/regions.ts
+++ b/src/regions.ts
@@ -1,6 +1,7 @@
 /** extract ordered regions from an image to turn into notes */
 
-import type { RGB } from "./colors";
+import { type HSLC, type RGB, rgb2hslc } from "./colors";
+import { ArrayVariance } from "./utils";
 
 export type RegionMethod = "grid";
 
@@ -9,6 +10,8 @@ export interface Region {
   num: number;
   poly: [number, number][];
   center: [number, number];
+  // total spread of the region's colors in the HSL cone; 0 when empty
+  variance: number;
 }
 
 // TODO custom ordering
@@ -41,6 +44,14 @@ function* patch(
   }
 }
 
+function colorVariance(colors: Iterable<RGB>): number {
+  const spread = new ArrayVariance<HSLC>();
+  for (const color of colors) {
+    spread.push(rgb2hslc(color));
+  }
+  return spread.total ?? 0;
+}
+
 /** a single region */
 export function* single(img: ImageData): Generator<Region> {
   const colors = patch(img, 0, 0, img.width, img.height);
@@ -52,7 +63,8 @@ export function* single(img: ImageData): Generator<Region> {
     [0, img.height],
   ];
   const center: [number, number] = [img.width / 2, img.height / 2];
-  yield { colors, num, poly, center };
+  const variance = colorVariance(patch(img, 0, 0, img.width, img.height));
+  yield { colors, num, poly, center, variance };
 }
 
 /** an ordered set of apprximately square patches */
@@ -85,8 +97,9 @@ export function* orderedGrid(img: ImageData, notes: number): Generator<Region> {
         imin + (imax - imin) / 2,
         jmin + (jmax - jmin) / 2,
       ];
+      const variance = colorVariance(patch(img, imin, jmin, imax, jmax));
 
-      yield { colors, num, poly, center };
+      yield { colors, num, poly, center, variance };
     }
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -43,6 +43,44 @@ export class ArrayMean<V extends readonly number[] = readonly number[]> {
   }
 }
 
+export class ArrayVariance<V extends readonly number[] = readonly number[]> {
+  #count = 0;
+  #mean: number[] | null = null;
+  #sumSq: number[] | null = null; // running sum of squared deviations per dim
+
+  push(arr: Readonly<V>): this {
+    this.#count++;
+    if (this.#mean === null || this.#sumSq === null) {
+      this.#mean = [...arr];
+      this.#sumSq = arr.map(() => 0);
+    } else if (this.#mean.length !== arr.length) {
+      throw new Error(
+        `mismatched lengths for variance: ${this.#mean.length} vs ${arr.length}`,
+      );
+    } else {
+      for (let i = 0; i < arr.length; ++i) {
+        const delta = arr[i] - this.#mean[i];
+        this.#mean[i] += delta / this.#count;
+        this.#sumSq[i] += delta * (arr[i] - this.#mean[i]);
+      }
+    }
+    return this;
+  }
+
+  /** population variance summed across every component, or null if empty */
+  get total(): number | null {
+    if (this.#sumSq === null || this.#count === 0) {
+      return null;
+    } else {
+      let total = 0;
+      for (const sumSq of this.#sumSq) {
+        total += sumSq / this.#count;
+      }
+      return total;
+    }
+  }
+}
+
 export class MaxBy<V> {
   #best: { weight: number; val: V } | null = null;
 

--- a/src/worker-interface.ts
+++ b/src/worker-interface.ts
@@ -1,5 +1,6 @@
 import type { ColorChoice } from "./extraction";
 import type { NoteConversion } from "./notes";
+import type { OrderMethod } from "./order";
 import type { RefineMethod } from "./refine";
 import type { RegionMethod } from "./regions";
 
@@ -22,6 +23,7 @@ export interface Message {
   bpm: number;
   duration: number;
   region: RegionMethod;
+  order: OrderMethod;
   colorChoice: ColorChoice;
   minStd: number;
   noteMethod: NoteConversion;

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -2,6 +2,7 @@ import { v4 as uuid } from "uuid";
 import { type HSLC, hslc2rgb, rgb2hex, rgb2hslc } from "./colors";
 import { extract } from "./extraction";
 import { color2note } from "./notes";
+import { order } from "./order";
 import { refine } from "./refine";
 import { regions } from "./regions";
 import { ArrayMean, MaxBy } from "./utils";
@@ -18,6 +19,7 @@ addEventListener("message", (event: MessageEvent<Message>) => {
       minStd,
       noteMethod,
       region,
+      order: orderMethod,
       refineMethod,
       minWeight,
       maxNotes,
@@ -27,12 +29,14 @@ addEventListener("message", (event: MessageEvent<Message>) => {
 
     const chords: Chord[] = [];
     const weightedNotes: [string, number][][] = [];
-    for (const { colors, num, poly, center } of regions(
-      img,
-      region,
-      approxBeats,
-    )) {
-      const weighted = extract(colors, colorChoice, { num, maxNotes, minStd });
+    // playback order is independent of how regions were carved
+    const ordered = order([...regions(img, region, approxBeats)], orderMethod);
+    for (const { colors, num, poly, center } of ordered) {
+      const weighted = extract(colors, colorChoice, {
+        num,
+        maxNotes,
+        minStd,
+      });
 
       // NOTE not currently using saturation / chroma
       const counts = new Map<


### PR DESCRIPTION
make playback order an independent concept
- word order: left -> right, top -> bottom
- focal spiral: start at focus, spiral out
